### PR TITLE
Sort countries alphabeitcally in the AP settings

### DIFF
--- a/librarian_netinterfaces/consts.py
+++ b/librarian_netinterfaces/consts.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 
+import locale
+
+from bottle_utils.lazy import Lazy
+from bottle_utils.common import unicode
 from bottle_utils.i18n import lazy_gettext as _
 
-COUNTRIES = (
-    ("", _("No country")),
+COUNTRY_CHOICES = (
     ("AF", _("Afghanistan, Islamic Republic of")),
     ("AL", _("Albania, Republic of")),
     ("DZ", _("Algeria, People's Democratic Republic of")),
@@ -259,7 +262,10 @@ COUNTRIES = (
     ("XS", _("Spratly Islands")),
 )
 
-COUNTRY_CODES = [i[0] for i in COUNTRIES]
+COUNTRIES = Lazy(lambda: sorted(COUNTRY_CHOICES, key=lambda x: unicode(x[1]),
+                                cmp=locale.strcoll))
+
+COUNTRY_CODES = [""] +  [i[0] for i in COUNTRY_CHOICES]
 
 CHANNELS = [(str(i), str(i)) for i in range(1, 14)]
 

--- a/librarian_netinterfaces/views/netinterfaces/_wireless_form.tpl
+++ b/librarian_netinterfaces/views/netinterfaces/_wireless_form.tpl
@@ -6,14 +6,16 @@ ${forms.form_errors([form.error]) if form.error else ''}
 ${forms.field(form.ssid, label=_('Access point name'))}
 ## Translators, label for a checkbox that enables hidden access point
 ${forms.field(form.hide_ssid, label=_('Do not show in scan lists'))}
-${forms.field(form.country, label=_('Country'), 
+${forms.field(form.country, label=_('Country'),
     ## Translators, WiFi has country-specific frequency regulations
-    help=_("Meet regional Wi-Fi frequency requirements"))}
+    help=_("Meet regional Wi-Fi frequency requirements"),
+    ## Translators, value used in country list for WiFi access point
+    empty_value=_("No country"))}
 ${forms.field(form.channel, label=_('Channel'))}
 ${forms.field(form.security, label=_('Security'))}
 ${forms.field(form.password, label=_('Password'), autocomplete=False)}
 % if form.show_driver:
-    ## Translators, wireless device type, shown next to access point driver 
+    ## Translators, wireless device type, shown next to access point driver
     ## selection drop-down
     ${forms.field(form.driver, label=_('Device type'))}
 % else:


### PR DESCRIPTION
This patch changes the country list for the wireless AP settings so they are
always sorted alphabetically, taking into account i18n. The sorting is done
using locale.strcoll as the comparison function so reasonably correct
sorting is expected for various languages.

Because we are wrapping the sorting code in bottle_utils.lazy.Lazy, the
null-value item is set using empty_value kwarg, which requires
Outernet-Project/librarian#340 to be merged.

Fixes #6 
