### PR TITLE
Initial implementation of wireless STA and remote mode configuration

### DIFF
--- a/librarian_netinterfaces/config.ini
+++ b/librarian_netinterfaces/config.ini
@@ -19,7 +19,15 @@ templates = views
 config = /etc/hostapd.conf
 
 # Hostapd service management commands
-restart_command = service hostapd restart
+restart_command = reboot
 
 # Whether to allow driver selection
 driver_selection = yes
+
+[remote]
+
+# Path to file containing the remote configuration file
+file = /mnt/conf/REMOTE
+
+# Filename to use when disabling remote mode
+disabled = /mnt/conf/REMOTE.disabled

--- a/librarian_netinterfaces/consts.py
+++ b/librarian_netinterfaces/consts.py
@@ -297,6 +297,6 @@ DRIVERS = (
 AP_MODE = 'ap'
 STA_MODE = 'sta'
 MODES = (
-    (AP_MODE, _('Access point mode')),
-    (STA_MODE, _('Station mode')),
+    (AP_MODE, _('Create a hotspot')),
+    (STA_MODE, _('Connect to a wireless network')),
 )

--- a/librarian_netinterfaces/consts.py
+++ b/librarian_netinterfaces/consts.py
@@ -293,3 +293,10 @@ DRIVERS = (
     (STANDARD, _('Standard (most devices)')),
     (ALTERNATIVE, _('Alternative (Realtek-based devices)'))
 )
+
+AP_MODE = 'ap'
+STA_MODE = 'sta'
+MODES = (
+    (AP_MODE, _('Access point mode')),
+    (STA_MODE, _('Station mode')),
+)

--- a/librarian_netinterfaces/dashboard_plugin.py
+++ b/librarian_netinterfaces/dashboard_plugin.py
@@ -27,5 +27,6 @@ class NetInterfacesDashboardPlugin(DashboardPlugin):
         return 'dashboard/' + self.name
 
     def get_context(self):
-        form = WifiForm.from_conf_file()
+        form_cls = WifiForm.get_form_class()
+        form = form_cls.from_conf_file()
         return dict(interfaces=get_network_interfaces(), form=form)

--- a/librarian_netinterfaces/remote.py
+++ b/librarian_netinterfaces/remote.py
@@ -1,0 +1,39 @@
+"""
+Copyright 2014-2015, Outernet Inc.
+Some rights reserved.
+
+This software is free software licensed under the terms of GPLv3. See COPYING
+file that comes with the source code, or http://www.gnu.org/licenses/gpl.txt.
+"""
+
+import os
+
+from librarian.core.exts import ext_container as exts
+
+
+REMOTE_TEMPLATE = '''
+SSID="{ssid}"
+PASSCODE="{password}"
+KEY="{key}"
+'''
+
+
+def setup(params):
+    """
+    Save remote configuration based on the passed in ``params``.
+    """
+    ssid = params['wireless.ssid']
+    password = params['wireless.password']
+    key = params['wireless.remote_key']
+    data = REMOTE_TEMPLATE.format(ssid=ssid, password=password, key=key)
+    with open(exts.config['remote.file'], 'w') as remote_file:
+        remote_file.write(data)
+
+
+def teardown():
+    """
+    Turn off remote mode.
+    """
+    remote_file = exts.config['remote.file']
+    if os.path.exists(remote_file):
+        os.rename(remote_file, exts.config['remote.disabled'])

--- a/librarian_netinterfaces/static/js/wireless_form.js
+++ b/librarian_netinterfaces/static/js/wireless_form.js
@@ -2,11 +2,13 @@
 var indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
 (function(window, $, templates) {
-  var NORTH_AMERICA, errorMessage, form, generateOptions, initPlugin, resizeSection, section, submitForm, togglePassword, updateChannels, url;
+  var NORTH_AMERICA, errorMessage, form, formContainer, generateOptions, initPlugin, modeForm, resizeSection, section, submitForm, switchMode, togglePassword, toggleSwitch, updateChannels, url;
   NORTH_AMERICA = ['US', 'CA'];
   errorMessage = templates.dashboardPluginError;
   section = $('#dashboard-netinterfaces');
+  formContainer = null;
   form = null;
+  modeForm = null;
   url = null;
   resizeSection = function() {
     section.trigger('remax');
@@ -49,21 +51,44 @@ var indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i 
     e.preventDefault();
     res = $.post(url, form.serialize());
     res.done(function(data) {
-      form.html(data);
+      formContainer.html(data);
       ($(window)).trigger('wireless-updated');
-      togglePassword();
-      updateChannels();
+      initPlugin();
+    });
+    res.fail(function() {
+      form.prepend(errorMessage);
+    });
+  };
+  toggleSwitch = function() {
+    var select;
+    select = $(this);
+    return modeForm.submit();
+  };
+  switchMode = function(e) {
+    var res;
+    e.preventDefault();
+    res = $.get(url, modeForm.serialize());
+    res.done(function(data) {
+      formContainer.html(data);
+      initPlugin();
     });
     res.fail(function() {
       form.prepend(errorMessage);
     });
   };
   initPlugin = function(e) {
+    var button;
+    formContainer = section.find('.wireless-settings');
     form = section.find('#wireless-form');
+    modeForm = section.find('#mode-form');
     url = form.attr('action');
     form.on('change', '#security', togglePassword);
     form.on('change', '#country', updateChannels);
     form.on('submit', submitForm);
+    modeForm.on('change', '#mode', toggleSwitch);
+    modeForm.on('submit', switchMode);
+    button = modeForm.find('button');
+    button.hide();
     togglePassword();
     return updateChannels();
   };

--- a/librarian_netinterfaces/views/dashboard/netinterfaces.tpl
+++ b/librarian_netinterfaces/views/dashboard/netinterfaces.tpl
@@ -67,6 +67,6 @@
     % endfor
 </ul>
 
-<form action="${i18n_url('netinterfaces:settings')}" method="POST" id="wireless-form" class="wireless-settings">
+<div class="wireless-settings">
     ${wireless_form.body()}
-</form>
+</div>

--- a/librarian_netinterfaces/views/netinterfaces/_ap_form.tpl
+++ b/librarian_netinterfaces/views/netinterfaces/_ap_form.tpl
@@ -1,0 +1,21 @@
+<%namespace name="forms" file="/ui/forms.tpl"/>
+
+${forms.field(form.ssid, label=_('Access point name'))}
+## Translators, label for a checkbox that enables hidden access point
+${forms.field(form.hide_ssid, label=_('Do not show in scan lists'))}
+${forms.field(form.country, label=_('Country'),
+    ## Translators, WiFi has country-specific frequency regulations
+    help=_("Meet regional Wi-Fi frequency requirements"),
+    ## Translators, value used in country list for WiFi access point
+    empty_value=_("No country"))}
+${forms.field(form.channel, label=_('Channel'))}
+${forms.field(form.security, label=_('Security'))}
+${forms.field(form.password, label=_('Password'), autocomplete=False)}
+% if form.show_driver:
+    ## Translators, wireless device type, shown next to access point driver
+    ## selection drop-down
+    ${forms.field(form.driver, label=_('Device type'))}
+% else:
+    ${h.HIDDEN('driver', '1')}
+% endif
+

--- a/librarian_netinterfaces/views/netinterfaces/_sta_form.tpl
+++ b/librarian_netinterfaces/views/netinterfaces/_sta_form.tpl
@@ -1,0 +1,5 @@
+<%namespace name="forms" file="/ui/forms.tpl"/>
+
+${forms.field(form.ssid, label=_('Access point name'))}
+${forms.field(form.password, label=_('Password'), autocomplete=False)}
+${forms.field(form.remote_key, label=_('Remote Key'))}

--- a/librarian_netinterfaces/views/netinterfaces/_wireless_form.tpl
+++ b/librarian_netinterfaces/views/netinterfaces/_wireless_form.tpl
@@ -1,27 +1,18 @@
 <%namespace name="forms" file="/ui/forms.tpl"/>
+<%namespace name="wifi_form" file="_${context['form'].MODE}_form.tpl"/>
 
 ${forms.form_message(message) if message else ''}
 ${forms.form_errors([form.error]) if form.error else ''}
 
-${forms.field(form.ssid, label=_('Access point name'))}
-## Translators, label for a checkbox that enables hidden access point
-${forms.field(form.hide_ssid, label=_('Do not show in scan lists'))}
-${forms.field(form.country, label=_('Country'),
-    ## Translators, WiFi has country-specific frequency regulations
-    help=_("Meet regional Wi-Fi frequency requirements"),
-    ## Translators, value used in country list for WiFi access point
-    empty_value=_("No country"))}
-${forms.field(form.channel, label=_('Channel'))}
-${forms.field(form.security, label=_('Security'))}
-${forms.field(form.password, label=_('Password'), autocomplete=False)}
-% if form.show_driver:
-    ## Translators, wireless device type, shown next to access point driver
-    ## selection drop-down
-    ${forms.field(form.driver, label=_('Device type'))}
-% else:
-    ${h.HIDDEN('driver', '1')}
-% endif
+<form action="${i18n_url('netinterfaces:settings')}" method="GET" id="mode-form">
+    ${forms.field(form.mode, label=_('Operating Mode'))}
+    <button type="submit">${_('Switch')}</button>
+</form>
 
-<p class="buttons">
-    <button type="submit">${_('Save')}</button>
-</p>
+<form action="${i18n_url('netinterfaces:settings')}" method="POST" id="wireless-form">
+    ${h.HIDDEN('mode', form.MODE)}
+    ${wifi_form.body()}
+    <p class="buttons">
+        <button type="submit">${_('Save and Reboot')}</button>
+    </p>
+</form>

--- a/librarian_netinterfaces/views/netinterfaces/wireless_settings.tpl
+++ b/librarian_netinterfaces/views/netinterfaces/wireless_settings.tpl
@@ -12,9 +12,7 @@ ${_('Access point settings')}
     <span>${_('Access point settings')}</span>
 </h2>
 
-<form action="${i18n_url('netinterfaces:settings')}" method="POST" id="wireless-form">
-    ${wireless_form.body()}
-</form>
+${wireless_form.body()}
 
 <%block name="extra_scripts">
     <script src="${assets['js/wireless_form']}"></script>

--- a/src/coffee/wireless_form.coffee
+++ b/src/coffee/wireless_form.coffee
@@ -3,7 +3,9 @@
 
   errorMessage = templates.dashboardPluginError
   section = $ '#dashboard-netinterfaces'
+  formContainer = null
   form = null
+  modeForm = null
   url = null
 
   resizeSection = () ->
@@ -47,10 +49,27 @@
     e.preventDefault()
     res = $.post url, form.serialize()
     res.done (data) ->
-      form.html data
+      formContainer.html data
       ($ window).trigger 'wireless-updated'
-      togglePassword()
-      updateChannels()
+      initPlugin()
+      return
+    res.fail () ->
+      form.prepend errorMessage
+      return
+    return
+
+
+  toggleSwitch = () ->
+    select = $ @
+    modeForm.submit()
+
+
+  switchMode = (e) ->
+    e.preventDefault()
+    res = $.get url, modeForm.serialize()
+    res.done (data) ->
+      formContainer.html data
+      initPlugin()
       return
     res.fail () ->
       form.prepend errorMessage
@@ -59,11 +78,17 @@
 
 
   initPlugin = (e) ->
+    formContainer = section.find '.wireless-settings'
     form = section.find '#wireless-form'
+    modeForm = section.find '#mode-form'
     url = form.attr 'action'
     form.on 'change', '#security', togglePassword
     form.on 'change', '#country', updateChannels
     form.on 'submit', submitForm
+    modeForm.on 'change', '#mode', toggleSwitch
+    modeForm.on 'submit', switchMode
+    button = modeForm.find 'button'
+    button.hide()
 
     togglePassword()
     updateChannels()


### PR DESCRIPTION
Saving of settings now performs a device reboot, please comment whether that's acceptable or not. The reason for going with it is because there is no backup of some of the config files modified at runtime by remotesetup, like dnsmasq config, thus a reboot restores it's original state, e.g. when going back from STA to AP mode. 
